### PR TITLE
#153728007 User should be able to configure periodic reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ install:
     - pip install braintree coveralls mock mysqlclient
 env:
   - DB=sqlite
-  - DB=mysql
   - DB=postgres
 addons:
   postgresql: "9.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 env:
   - DB=sqlite
   - DB=postgres
+  - SITE_ROOT="https://hclogros.herokuapp.com/"  
 addons:
   postgresql: "9.4"
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ install:
     - pip install -r requirements.txt
     - pip install braintree coveralls mock mysqlclient
 env:
-  - DB=postgres
   - SITE_ROOT="https://hclogros.herokuapp.com/"  
+  - DB=postgres
 addons:
   postgresql: "9.4"
 before_script:

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -126,7 +126,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-SITE_ROOT = "https://hclogros.herokuapp.com"
+SITE_ROOT = os.getenv("SITE_ROOT")
 SITE_NAME = "Health Checks"
 
 PING_ENDPOINT = SITE_ROOT + "/ping/"

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -126,7 +126,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-SITE_ROOT = "https://hc-logros.herokuapp.com"
+SITE_ROOT = "https://hclogros.herokuapp.com"
 SITE_NAME = "Health Checks"
 
 PING_ENDPOINT = SITE_ROOT + "/ping/"

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -32,24 +32,30 @@
                             value="monthly"
                             {% if profile.reports_allowed == "monthly" %} checked{% endif %}>
                             Monthly
+                    </label>
+                    <label>
                         <input
                             name="reports_allowed"
                             type="radio"
                             value="weekly"
                             {% if profile.reports_allowed == "weekly" %} checked {% endif %}>
                             Weekly
+                    </label>
+                    <label>
                         <input
                             name="reports_allowed"
                             type="radio"
                             value="daily"
                             {% if profile.reports_allowed == "daily" %} checked{% endif %}>
-                            daily
+                            Daily
+                    </label>
+                    <label>
                         <input
                             name="reports_allowed"
                             type="radio"
                             value="instant"
                             {% if profile.reports_allowed == "instant" %} checked{% endif %}>
-                            instant
+                            Instant
                     </label>
                     <button
                         name="update_reports_allowed"

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -22,41 +22,26 @@
     <div class="col-sm-6">
         <div class="panel panel-default">
             <div class="panel-body settings-block">
-                <form method="post">
+                <form method="post" class="form-inline" id="periodic">
                     {% csrf_token %}
-                    <h2>Periodic Reports</h2>
-                    <label>
-                        <input
-                            name="reports_allowed"
-                            type="radio"
-                            value="monthly"
-                            {% if profile.reports_allowed == "monthly" %} checked{% endif %}>
-                            Monthly
-                    </label>
-                    <label>
-                        <input
-                            name="reports_allowed"
-                            type="radio"
-                            value="weekly"
-                            {% if profile.reports_allowed == "weekly" %} checked {% endif %}>
-                            Weekly
-                    </label>
-                    <label>
-                        <input
-                            name="reports_allowed"
-                            type="radio"
-                            value="daily"
-                            {% if profile.reports_allowed == "daily" %} checked{% endif %}>
-                            Daily
-                    </label>
-                    <label>
-                        <input
-                            name="reports_allowed"
-                            type="radio"
-                            value="instant"
-                            {% if profile.reports_allowed == "instant" %} checked{% endif %}>
-                            Instant
-                    </label>
+                    <h2>Email reports</h2>
+                    <div class="btn-group" data-toggle="buttons">
+                        <label {% if profile.reports_allowed == "monthly" %} class="btn btn-primary"{% endif %} class="btn btn-default">
+                            <input name="reports_allowed" type="radio" value="monthly">Monthly
+                        </label>
+                        <label {% if profile.reports_allowed == "weekly" %} class="btn btn-primary"{% endif %} class="btn btn-default">
+                            <input name="reports_allowed" type="radio" value="weekly" 
+                            {% if profile.reports_allowed == "weekly" %} checked{% endif %}> Weekly
+                        </label>
+                        <label {% if profile.reports_allowed == "daily" %} class="btn btn-primary"{% endif %} class="btn btn-default">
+                            <input name="reports_allowed" type="radio" value="daily" 
+                            {% if profile.reports_allowed == "daily" %} checked{% endif %}> Daily
+                        </label>
+                        <label {% if profile.reports_allowed == "instant" %} class="btn btn-primary"{% endif %} class="btn btn-default">
+                            <input name="reports_allowed" type="radio" value="instant" 
+                            {% if profile.reports_allowed == "instant" %} checked{% endif %}> Instant
+                        </label>
+                    </div>
                     <button
                         name="update_reports_allowed"
                         type="submit"


### PR DESCRIPTION
#### What does this PR do?
Merge changes made on the UI for the periodic report's settings that were changed since the last merge.
#### Description of Task to be completed?
A user should be able to configure periodic reports i.e Daily, Weekly, Monthly and this should be received in the email.
#### How should this be manually tested?
Go to account settings, configure the reports you wanr]t to receive and when the time reaches to receive the reports, you will be able to receive the reports directly to your email.
#### What are the relevant pivotal tracker stories?
[#153728007](https://www.pivotaltracker.com/story/show/153728007)
#### Screenshots (if appropriate)
<img width="578" alt="screen shot 2018-02-06 at 08 22 09" src="https://user-images.githubusercontent.com/15800486/35843010-e1e176c4-0b16-11e8-8059-989d92db9e59.png">
